### PR TITLE
feat: add docker-compose for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,23 @@
 # Google OAuth Configuration
+# Create credentials at: https://console.cloud.google.com/apis/credentials
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URI=http://localhost:3000/auth/callback
 
 # Database Configuration (PostgreSQL)
-DATABASE_URL=postgresql://user:password@localhost:5432/yomu
+# For docker-compose (default ports): postgresql://yomu:yomu@localhost:5433/yomu
+DATABASE_URL=postgresql://yomu:yomu@localhost:5433/yomu
 
 # Valkey (Redis-compatible) Configuration
-VALKEY_URL=redis://localhost:6379
+# For docker-compose (default ports): redis://localhost:6380
+VALKEY_URL=redis://localhost:6380
 
-# Session Configuration
-SESSION_SECRET=your-session-secret-min-32-chars-long
+# Docker Compose port overrides (optional)
+# POSTGRES_PORT=5433
+# VALKEY_PORT=6380
+
+# Session Configuration (minimum 32 characters)
+SESSION_SECRET=change-this-to-a-secure-random-string-min-32-chars
 
 # Application Configuration
 NODE_ENV=development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,30 +1,73 @@
 # yomu Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-01-02
+Auto-generated from all feature plans. Last updated: 2026-01-04
 
 ## Active Technologies
 
-- TypeScript (latest stable) (001-google-oauth-auth)
+- TypeScript (latest stable)
+- PostgreSQL 16
+- Valkey (Redis-compatible)
 
 ## Project Structure
 
 ```text
-src/
-tests/
+apps/
+  api/     # Hono API server with tRPC
+  cli/     # CLI with Google OAuth
+docker/
+  postgres/init.sql  # Database schema
+specs/     # Feature specifications
+```
+
+## Quick Start
+
+```bash
+# 1. Start infrastructure
+docker compose up -d
+
+# 2. Copy environment file
+cp .env.example .env
+# Edit .env with your Google OAuth credentials
+
+# 3. Install dependencies
+pnpm install
+
+# 4. Start API server
+pnpm --filter @yomu/api dev
+
+# 5. Use CLI
+pnpm --filter @yomu/cli exec tsx src/index.ts --help
 ```
 
 ## Commands
 
-npm test && npm run lint
+```bash
+# Run all tests
+pnpm test
+
+# Run linting
+pnpm lint
+
+# Type checking
+pnpm typecheck
+
+# Docker
+docker compose up -d    # Start services
+docker compose down     # Stop services
+docker compose logs -f  # View logs
+```
 
 ## Code Style
 
 TypeScript (latest stable): Follow standard conventions
 
-## Recent Changes
-- 002-cli-google-oauth: Added TypeScript (latest stable)
+## Ports
 
-- 001-google-oauth-auth: Added TypeScript (latest stable)
+| Service    | Default Port |
+|------------|-------------|
+| API        | 3000        |
+| PostgreSQL | 5433        |
+| Valkey     | 6380        |
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: yomu-postgres
+    environment:
+      POSTGRES_USER: yomu
+      POSTGRES_PASSWORD: yomu
+      POSTGRES_DB: yomu
+    ports:
+      - "${POSTGRES_PORT:-5433}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U yomu -d yomu"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  valkey:
+    image: valkey/valkey:8-alpine
+    container_name: yomu-valkey
+    ports:
+      - "${VALKEY_PORT:-6380}:6379"
+    volumes:
+      - valkey_data:/data
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  valkey_data:

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,0 +1,30 @@
+-- Yomu Database Schema
+-- This script runs automatically when the PostgreSQL container is first created
+
+CREATE TABLE IF NOT EXISTS users (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    google_id varchar(255) NOT NULL UNIQUE,
+    email varchar(255) NOT NULL,
+    display_name varchar(255),
+    profile_picture text,
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    last_sign_in_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token varchar(512) NOT NULL UNIQUE,
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    expires_at timestamp with time zone NOT NULL,
+    last_activity_at timestamp with time zone NOT NULL DEFAULT now(),
+    user_agent text,
+    ip_address_hash varchar(64)
+);
+
+-- Indexes
+CREATE UNIQUE INDEX IF NOT EXISTS users_google_id_idx ON users(google_id);
+CREATE INDEX IF NOT EXISTS users_email_idx ON users(email);
+CREATE UNIQUE INDEX IF NOT EXISTS sessions_token_idx ON sessions(token);
+CREATE INDEX IF NOT EXISTS sessions_user_id_idx ON sessions(user_id);
+CREATE INDEX IF NOT EXISTS sessions_expires_at_idx ON sessions(expires_at);


### PR DESCRIPTION
## Summary

Add docker-compose for easy local development setup with all required services.

## Changes

- **docker-compose.yml**: PostgreSQL 16 + Valkey with health checks
- **docker/postgres/init.sql**: Database schema auto-initialization
- **.env.example**: Updated with docker-compose compatible defaults
- **CLAUDE.md**: Quick start instructions

## Services

| Service    | Container Port | Host Port (default) |
|------------|---------------|---------------------|
| PostgreSQL | 5432          | 5433                |
| Valkey     | 6379          | 6380                |

Ports are configurable via `POSTGRES_PORT` and `VALKEY_PORT` environment variables.

## Test plan

```bash
# Start services
docker compose up -d

# Verify PostgreSQL
docker exec yomu-postgres psql -U yomu -d yomu -c "\dt"

# Verify Valkey
docker exec yomu-valkey valkey-cli ping

# Stop services
docker compose down
```

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)