### PR TITLE
feat(feed-parser): add RSS 2.0, JSON Feed, and RDF parser support

### DIFF
--- a/packages/feed-parser/src/__fixtures__/jsonfeed.ts
+++ b/packages/feed-parser/src/__fixtures__/jsonfeed.ts
@@ -1,0 +1,37 @@
+export const FEED_URL = "https://example.com/feed.json"
+
+export const buildItem = (overrides: Record<string, unknown> = {}) => ({
+  id: "https://example.com/posts/1",
+  url: "https://example.com/posts/1",
+  title: "Test Item",
+  content_html: "<p>Test content</p>",
+  date_published: "2024-01-15T10:00:00Z",
+  date_modified: "2024-01-16T12:00:00Z",
+  authors: [{ name: "Alice" }],
+  tags: [],
+  ...overrides,
+})
+
+export const buildFeed = (
+  items: ReturnType<typeof buildItem>[],
+  overrides: Record<string, unknown> = {},
+) =>
+  JSON.stringify({
+    version: "https://jsonfeed.org/version/1.1",
+    title: "Test JSON Feed",
+    home_page_url: "https://example.com",
+    feed_url: FEED_URL,
+    description: "A test JSON feed",
+    items,
+    ...overrides,
+  })
+
+export const JSONFEED_SINGLE_ITEM = buildFeed([
+  buildItem({
+    title: "Mock JSON Item",
+    content_html: "<p>Hello from JSON Feed</p>",
+    date_published: "2024-03-01T00:00:00Z",
+    authors: [{ name: "Bob" }],
+    tags: ["TypeScript", "Bun"],
+  }),
+])

--- a/packages/feed-parser/src/__fixtures__/rdf.ts
+++ b/packages/feed-parser/src/__fixtures__/rdf.ts
@@ -1,0 +1,38 @@
+export const FEED_URL = "https://example.com/feed.rdf"
+
+export const buildItem = (overrides = "") => `
+  <item rdf:about="https://example.com/posts/1">
+    <title>Test Item</title>
+    <link>https://example.com/posts/1</link>
+    <description>Test content</description>
+    <dc:date>2024-01-15T10:00:00Z</dc:date>
+    <dc:creator>Alice</dc:creator>
+    ${overrides}
+  </item>
+`
+
+export const buildFeed = (items: string, overrides = "") => `
+  <?xml version="1.0" encoding="UTF-8"?>
+  <rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns="http://purl.org/rss/1.0/"
+    xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel rdf:about="${FEED_URL}">
+      <title>Test RDF Feed</title>
+      <link>https://example.com</link>
+      <description>A test RDF feed</description>
+      ${overrides}
+    </channel>
+    ${items}
+  </rdf:RDF>
+`
+
+export const RDF_SINGLE_ITEM = buildFeed(`
+  <item rdf:about="https://example.com/posts/1">
+    <title>Mock RDF Item</title>
+    <link>https://example.com/posts/1</link>
+    <description>Hello from RDF</description>
+    <dc:date>2024-03-01T00:00:00Z</dc:date>
+    <dc:creator>Bob</dc:creator>
+  </item>
+`)

--- a/packages/feed-parser/src/__fixtures__/rss2.ts
+++ b/packages/feed-parser/src/__fixtures__/rss2.ts
@@ -1,0 +1,39 @@
+export const FEED_URL = "https://example.com/feed.rss"
+
+export const buildItem = (overrides = "") => `
+  <item>
+    <title>Test Item</title>
+    <link>https://example.com/posts/1</link>
+    <guid isPermaLink="true">https://example.com/posts/1</guid>
+    <pubDate>Mon, 15 Jan 2024 10:00:00 GMT</pubDate>
+    <author>alice@example.com (Alice)</author>
+    <description>&lt;p&gt;Test content&lt;/p&gt;</description>
+    ${overrides}
+  </item>
+`
+
+export const buildFeed = (items: string, overrides = "") => `
+  <?xml version="1.0" encoding="UTF-8"?>
+  <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+      <title>Test RSS Feed</title>
+      <link>https://example.com</link>
+      <description>A test RSS feed</description>
+      ${overrides}
+      ${items}
+    </channel>
+  </rss>
+`
+
+export const RSS2_SINGLE_ITEM = buildFeed(`
+  <item>
+    <title>Mock RSS Item</title>
+    <link>https://example.com/posts/1</link>
+    <guid>https://example.com/posts/1</guid>
+    <pubDate>Fri, 01 Mar 2024 00:00:00 GMT</pubDate>
+    <author>bob@example.com (Bob)</author>
+    <description>&lt;p&gt;Hello from RSS&lt;/p&gt;</description>
+    <category>TypeScript</category>
+    <category>Bun</category>
+  </item>
+`)

--- a/packages/feed-parser/src/index.test.ts
+++ b/packages/feed-parser/src/index.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
 import { fetchFeed } from "./index.js"
 import { ATOM_SINGLE_ENTRY } from "./__fixtures__/atom.js"
+import { RSS2_SINGLE_ITEM } from "./__fixtures__/rss2.js"
+import { JSONFEED_SINGLE_ITEM } from "./__fixtures__/jsonfeed.js"
+import { RDF_SINGLE_ITEM } from "./__fixtures__/rdf.js"
 import { mockFetch } from "./test-utils.js"
 
 afterEach(() => {
@@ -8,40 +11,78 @@ afterEach(() => {
 })
 
 describe("fetchFeed", () => {
-  it("Atom フィードを取得してパースする", async () => {
-    mockFetch(ATOM_SINGLE_ENTRY)
-    const feed = await fetchFeed("https://example.com/feed.atom")
-    expect(feed.title).toBe("Test Feed")
-    expect(feed.entries).toHaveLength(1)
-    expect(feed.entries[0].title).toBe("Mock Post")
-    expect(feed.entries[0].author).toBe("Bob")
-    expect(feed.entries[0].contentType).toBe("html")
-  })
+  describe("フォーマット判定（content-type）", () => {
+    it("application/atom+xml → Atom パーサーへ", async () => {
+      mockFetch(ATOM_SINGLE_ENTRY, { contentType: "application/atom+xml" })
+      const feed = await fetchFeed("https://example.com/feed.atom")
+      expect(feed.title).toBe("Test Feed")
+    })
 
-  it("content-type が atom でなくても <feed> タグで Atom と判定する", async () => {
-    mockFetch(ATOM_SINGLE_ENTRY, { contentType: "text/xml" })
-    const feed = await fetchFeed("https://example.com/feed")
-    expect(feed.title).toBe("Test Feed")
-  })
+    it("application/rss+xml → RSS 2.0 パーサーへ", async () => {
+      mockFetch(RSS2_SINGLE_ITEM, { contentType: "application/rss+xml" })
+      const feed = await fetchFeed("https://example.com/feed.rss")
+      expect(feed.title).toBe("Test RSS Feed")
+    })
 
-  it("User-Agent ヘッダを付けてリクエストする", async () => {
-    mockFetch(ATOM_SINGLE_ENTRY)
-    await fetchFeed("https://example.com/feed.atom")
-    const call = vi.mocked(fetch).mock.calls[0]
-    expect((call[1] as RequestInit).headers).toMatchObject({
-      "User-Agent": expect.stringContaining("Yomu"),
+    it("application/feed+json → JSON Feed パーサーへ", async () => {
+      mockFetch(JSONFEED_SINGLE_ITEM, { contentType: "application/feed+json" })
+      const feed = await fetchFeed("https://example.com/feed.json")
+      expect(feed.title).toBe("Test JSON Feed")
+    })
+
+    it("application/rdf+xml → RDF パーサーへ", async () => {
+      mockFetch(RDF_SINGLE_ITEM, { contentType: "application/rdf+xml" })
+      const feed = await fetchFeed("https://example.com/feed.rdf")
+      expect(feed.title).toBe("Test RDF Feed")
     })
   })
 
-  it("HTTP エラーなら例外を投げる", async () => {
-    mockFetch("Not Found", { status: 404, contentType: "text/plain" })
-    await expect(fetchFeed("https://example.com/feed.atom")).rejects.toThrow("HTTP 404")
+  describe("フォーマット判定（コンテンツスニッフィング）", () => {
+    it("<feed> タグで Atom と判定する", async () => {
+      mockFetch(ATOM_SINGLE_ENTRY, { contentType: "text/xml" })
+      const feed = await fetchFeed("https://example.com/feed")
+      expect(feed.title).toBe("Test Feed")
+    })
+
+    it("<rss> タグで RSS 2.0 と判定する", async () => {
+      mockFetch(RSS2_SINGLE_ITEM, { contentType: "text/xml" })
+      const feed = await fetchFeed("https://example.com/feed")
+      expect(feed.title).toBe("Test RSS Feed")
+    })
+
+    it("{ で始まる JSON で JSON Feed と判定する", async () => {
+      mockFetch(JSONFEED_SINGLE_ITEM, { contentType: "text/plain" })
+      const feed = await fetchFeed("https://example.com/feed")
+      expect(feed.title).toBe("Test JSON Feed")
+    })
+
+    it("<rdf:RDF> タグで RDF と判定する", async () => {
+      mockFetch(RDF_SINGLE_ITEM, { contentType: "text/xml" })
+      const feed = await fetchFeed("https://example.com/feed")
+      expect(feed.title).toBe("Test RDF Feed")
+    })
   })
 
-  it("未対応フォーマットなら例外を投げる", async () => {
-    mockFetch("<rss><channel/></rss>", { contentType: "application/rss+xml" })
-    await expect(fetchFeed("https://example.com/feed.rss")).rejects.toThrow(
-      "Unsupported feed format",
-    )
+  describe("エラーケース", () => {
+    it("User-Agent ヘッダを付けてリクエストする", async () => {
+      mockFetch(ATOM_SINGLE_ENTRY)
+      await fetchFeed("https://example.com/feed.atom")
+      const call = vi.mocked(fetch).mock.calls[0]
+      expect((call[1] as RequestInit).headers).toMatchObject({
+        "User-Agent": expect.stringContaining("Yomu"),
+      })
+    })
+
+    it("HTTP エラーなら例外を投げる", async () => {
+      mockFetch("Not Found", { status: 404, contentType: "text/plain" })
+      await expect(fetchFeed("https://example.com/feed.atom")).rejects.toThrow("HTTP 404")
+    })
+
+    it("未対応フォーマットなら例外を投げる", async () => {
+      mockFetch("<html><body/></html>", { contentType: "text/html" })
+      await expect(fetchFeed("https://example.com/")).rejects.toThrow(
+        "Unsupported feed format",
+      )
+    })
   })
 })

--- a/packages/feed-parser/src/index.ts
+++ b/packages/feed-parser/src/index.ts
@@ -1,7 +1,29 @@
 import { parseAtom } from "./parsers/atom.js"
+import { parseRss2 } from "./parsers/rss2.js"
+import { parseJsonFeed } from "./parsers/jsonfeed.js"
+import { parseRdf } from "./parsers/rdf.js"
 import type { Feed } from "./types.js"
 
 export type { Feed, Entry } from "./types.js"
+
+type Format = "atom" | "rss2" | "jsonfeed" | "rdf"
+
+function detectFormat(contentType: string, body: string): Format {
+  if (contentType.includes("application/feed+json") || contentType.includes("application/json")) {
+    return "jsonfeed"
+  }
+  if (contentType.includes("application/rdf+xml")) return "rdf"
+  if (contentType.includes("application/rss+xml")) return "rss2"
+  if (contentType.includes("application/atom+xml")) return "atom"
+
+  const sniff = body.trimStart()
+  if (sniff.startsWith("{")) return "jsonfeed"
+  if (sniff.includes("<rdf:RDF")) return "rdf"
+  if (sniff.includes("<rss")) return "rss2"
+  if (sniff.includes("<feed")) return "atom"
+
+  throw new Error(`Unsupported feed format (content-type: ${contentType})`)
+}
 
 export async function fetchFeed(url: string): Promise<Feed> {
   const res = await fetch(url, {
@@ -9,12 +31,14 @@ export async function fetchFeed(url: string): Promise<Feed> {
   })
   if (!res.ok) throw new Error(`HTTP ${res.status}: ${url}`)
 
-  const text = await res.text()
+  const body = await res.text()
   const contentType = res.headers.get("content-type") ?? ""
+  const format = detectFormat(contentType, body)
 
-  if (contentType.includes("atom") || text.trimStart().includes("<feed")) {
-    return parseAtom(text, url)
+  switch (format) {
+    case "atom":     return parseAtom(body, url)
+    case "rss2":     return parseRss2(body, url)
+    case "jsonfeed": return parseJsonFeed(body, url)
+    case "rdf":      return parseRdf(body, url)
   }
-
-  throw new Error(`Unsupported feed format (content-type: ${contentType})`)
 }

--- a/packages/feed-parser/src/parsers/jsonfeed.test.ts
+++ b/packages/feed-parser/src/parsers/jsonfeed.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest"
+import { parseJsonFeed } from "./jsonfeed.js"
+import { FEED_URL, buildItem, buildFeed } from "../__fixtures__/jsonfeed.js"
+
+describe("parseJsonFeed", () => {
+  describe("フィードレベル", () => {
+    it("title・siteUrl・description を取得する", () => {
+      const feed = parseJsonFeed(buildFeed([]), FEED_URL)
+      expect(feed.title).toBe("Test JSON Feed")
+      expect(feed.siteUrl).toBe("https://example.com")
+      expect(feed.description).toBe("A test JSON feed")
+    })
+
+    it("version が jsonfeed.org を含まなければ例外を投げる", () => {
+      const json = JSON.stringify({ version: "1.0", title: "x", items: [] })
+      expect(() => parseJsonFeed(json, FEED_URL)).toThrow("Not a valid JSON feed")
+    })
+
+    it("JSON でなければ例外を投げる", () => {
+      expect(() => parseJsonFeed("<xml/>", FEED_URL)).toThrow("Not a valid JSON feed")
+    })
+  })
+
+  describe("エントリ基本フィールド", () => {
+    it("id・title・url・publishedAt・updatedAt・author・tags を取得する", () => {
+      const feed = parseJsonFeed(buildFeed([buildItem()]), FEED_URL)
+      const e = feed.entries[0]
+      expect(e.id).toBe("https://example.com/posts/1")
+      expect(e.title).toBe("Test Item")
+      expect(e.url).toBe("https://example.com/posts/1")
+      expect(e.publishedAt).toEqual(new Date("2024-01-15T10:00:00Z"))
+      expect(e.updatedAt).toEqual(new Date("2024-01-16T12:00:00Z"))
+      expect(e.author).toBe("Alice")
+    })
+
+    it("url がなければ例外を投げる", () => {
+      const item = buildItem({ url: undefined })
+      expect(() => parseJsonFeed(buildFeed([item]), FEED_URL)).toThrow()
+    })
+
+    it("date_published がなければ例外を投げる", () => {
+      const item = buildItem({ date_published: undefined })
+      expect(() => parseJsonFeed(buildFeed([item]), FEED_URL)).toThrow()
+    })
+  })
+
+  describe("content / contentType", () => {
+    it("content_html があれば contentType は html", () => {
+      const feed = parseJsonFeed(buildFeed([buildItem()]), FEED_URL)
+      expect(feed.entries[0].contentType).toBe("html")
+      expect(feed.entries[0].content).toBe("<p>Test content</p>")
+    })
+
+    it("content_text のみなら contentType は text", () => {
+      const item = buildItem({ content_html: undefined, content_text: "plain text" })
+      const feed = parseJsonFeed(buildFeed([item]), FEED_URL)
+      expect(feed.entries[0].contentType).toBe("text")
+      expect(feed.entries[0].content).toBe("plain text")
+    })
+  })
+
+  describe("authors", () => {
+    it("authors 配列から最初の name を使う", () => {
+      const item = buildItem({ authors: [{ name: "Carol" }, { name: "Dave" }] })
+      const feed = parseJsonFeed(buildFeed([item]), FEED_URL)
+      expect(feed.entries[0].author).toBe("Carol")
+    })
+
+    it("author (singular) にフォールバックする", () => {
+      const item = buildItem({ authors: undefined, author: { name: "Eve" } })
+      const feed = parseJsonFeed(buildFeed([item]), FEED_URL)
+      expect(feed.entries[0].author).toBe("Eve")
+    })
+  })
+
+  describe("tags", () => {
+    it("tags 配列をそのまま返す", () => {
+      const item = buildItem({ tags: ["TypeScript", "Bun"] })
+      const feed = parseJsonFeed(buildFeed([item]), FEED_URL)
+      expect(feed.entries[0].tags).toEqual(["TypeScript", "Bun"])
+    })
+
+    it("tags がなければ空配列", () => {
+      const item = buildItem({ tags: undefined })
+      const feed = parseJsonFeed(buildFeed([item]), FEED_URL)
+      expect(feed.entries[0].tags).toEqual([])
+    })
+  })
+})

--- a/packages/feed-parser/src/parsers/jsonfeed.ts
+++ b/packages/feed-parser/src/parsers/jsonfeed.ts
@@ -1,0 +1,75 @@
+import type { Feed, Entry } from "../types.js"
+
+type JsonFeedItem = {
+  id?: string
+  url?: string
+  title?: string
+  content_html?: string
+  content_text?: string
+  summary?: string
+  date_published?: string
+  date_modified?: string
+  author?: { name?: string }
+  authors?: { name?: string }[]
+  tags?: string[]
+}
+
+type JsonFeedDoc = {
+  version?: string
+  title?: string
+  home_page_url?: string
+  feed_url?: string
+  description?: string
+  items?: JsonFeedItem[]
+}
+
+function resolveDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined
+  const d = new Date(value)
+  return isNaN(d.getTime()) ? undefined : d
+}
+
+function resolveAuthor(item: JsonFeedItem): string | undefined {
+  if (item.authors?.length) return item.authors[0].name
+  return item.author?.name
+}
+
+export function parseJsonFeed(json: string, feedUrl: string): Feed {
+  let doc: JsonFeedDoc
+  try {
+    doc = JSON.parse(json)
+  } catch {
+    throw new Error("Not a valid JSON feed")
+  }
+  if (!doc.version?.includes("jsonfeed.org")) throw new Error("Not a valid JSON feed")
+
+  const entries: Entry[] = (doc.items ?? []).map((item) => {
+    const url = item.url
+    if (!url) throw new Error(`Item missing url: ${JSON.stringify(item.id)}`)
+    const publishedAt = resolveDate(item.date_published)
+    if (!publishedAt) throw new Error(`Item missing date_published: ${url}`)
+
+    const hasHtml = Boolean(item.content_html)
+
+    return {
+      id: item.id ?? url,
+      title: item.title ?? "(no title)",
+      url,
+      publishedAt,
+      updatedAt: resolveDate(item.date_modified),
+      content: item.content_html ?? item.content_text,
+      contentType: hasHtml ? "html" : "text",
+      summary: item.summary,
+      author: resolveAuthor(item),
+      tags: item.tags ?? [],
+    }
+  })
+
+  return {
+    title: doc.title ?? "(no title)",
+    feedUrl: doc.feed_url ?? feedUrl,
+    siteUrl: doc.home_page_url,
+    description: doc.description,
+    entries,
+  }
+}

--- a/packages/feed-parser/src/parsers/rdf.test.ts
+++ b/packages/feed-parser/src/parsers/rdf.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest"
+import { parseRdf } from "./rdf.js"
+import { FEED_URL, buildItem, buildFeed } from "../__fixtures__/rdf.js"
+
+describe("parseRdf", () => {
+  describe("フィードレベル", () => {
+    it("title・siteUrl・description を取得する", () => {
+      const feed = parseRdf(buildFeed(""), FEED_URL)
+      expect(feed.title).toBe("Test RDF Feed")
+      expect(feed.siteUrl).toBe("https://example.com")
+      expect(feed.description).toBe("A test RDF feed")
+    })
+
+    it("<rdf:RDF> がなければ例外を投げる", () => {
+      expect(() => parseRdf("<rss><channel/></rss>", FEED_URL)).toThrow(
+        "Not a valid RDF feed",
+      )
+    })
+  })
+
+  describe("エントリ基本フィールド", () => {
+    it("id・title・url・publishedAt・author を取得する", () => {
+      const feed = parseRdf(buildFeed(buildItem()), FEED_URL)
+      const e = feed.entries[0]
+      expect(e.id).toBe("https://example.com/posts/1")
+      expect(e.title).toBe("Test Item")
+      expect(e.url).toBe("https://example.com/posts/1")
+      expect(e.publishedAt).toEqual(new Date("2024-01-15T10:00:00Z"))
+      expect(e.author).toBe("Alice")
+      expect(e.contentType).toBe("html")
+    })
+
+    it("dc:date がなければ例外を投げる", () => {
+      const item = buildItem().replace(
+        "<dc:date>2024-01-15T10:00:00Z</dc:date>",
+        "",
+      )
+      expect(() => parseRdf(buildFeed(item), FEED_URL)).toThrow()
+    })
+
+    it("tags は常に空配列", () => {
+      const feed = parseRdf(buildFeed(buildItem()), FEED_URL)
+      expect(feed.entries[0].tags).toEqual([])
+    })
+  })
+})

--- a/packages/feed-parser/src/parsers/rdf.ts
+++ b/packages/feed-parser/src/parsers/rdf.ts
@@ -1,0 +1,63 @@
+import { XMLParser } from "fast-xml-parser"
+import type { Feed, Entry } from "../types.js"
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  isArray: (name) => name === "item",
+})
+
+function resolveText(value: unknown): string | undefined {
+  if (typeof value === "string") return value
+  if (typeof value === "object" && value !== null && "#text" in value) {
+    return String((value as { "#text": unknown })["#text"])
+  }
+  return undefined
+}
+
+function resolveDate(value: unknown): Date | undefined {
+  if (!value) return undefined
+  const d = new Date(String(value))
+  return isNaN(d.getTime()) ? undefined : d
+}
+
+export function parseRdf(xml: string, feedUrl: string): Feed {
+  const raw = parser.parse(xml)
+  const root = raw?.["rdf:RDF"]
+  if (!root) throw new Error("Not a valid RDF feed")
+
+  const channel = root.channel
+  const items: Record<string, unknown>[] = Array.isArray(root.item)
+    ? root.item
+    : root.item
+      ? [root.item]
+      : []
+
+  const entries: Entry[] = items.map((item) => {
+    const url = resolveText(item.link) ?? (item["@_rdf:about"] as string | undefined)
+    if (!url) throw new Error(`Item missing link: ${JSON.stringify(item.title)}`)
+    const publishedAt = resolveDate(item["dc:date"])
+    if (!publishedAt) throw new Error(`Item missing dc:date: ${url}`)
+
+    return {
+      id: (item["@_rdf:about"] as string | undefined) ?? url,
+      title: resolveText(item.title) ?? "(no title)",
+      url,
+      publishedAt,
+      updatedAt: undefined,
+      content: resolveText(item.description) ?? resolveText(item["content:encoded"]),
+      contentType: "html",
+      summary: undefined,
+      author: resolveText(item["dc:creator"]),
+      tags: [],
+    }
+  })
+
+  return {
+    title: resolveText(channel?.title) ?? "(no title)",
+    feedUrl,
+    siteUrl: resolveText(channel?.link),
+    description: resolveText(channel?.description),
+    entries,
+  }
+}

--- a/packages/feed-parser/src/parsers/rss2.test.ts
+++ b/packages/feed-parser/src/parsers/rss2.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest"
+import { parseRss2 } from "./rss2.js"
+import { FEED_URL, buildItem, buildFeed } from "../__fixtures__/rss2.js"
+
+describe("parseRss2", () => {
+  describe("フィードレベル", () => {
+    it("title・siteUrl・description を取得する", () => {
+      const feed = parseRss2(buildFeed(""), FEED_URL)
+      expect(feed.title).toBe("Test RSS Feed")
+      expect(feed.siteUrl).toBe("https://example.com")
+      expect(feed.description).toBe("A test RSS feed")
+    })
+
+    it("<channel> がなければ例外を投げる", () => {
+      expect(() => parseRss2("<rss version='2.0'/>", FEED_URL)).toThrow(
+        "Not a valid RSS 2.0 feed",
+      )
+    })
+  })
+
+  describe("エントリ基本フィールド", () => {
+    it("title・url・publishedAt・author・tags を取得する", () => {
+      const feed = parseRss2(buildFeed(buildItem()), FEED_URL)
+      const e = feed.entries[0]
+      expect(e.title).toBe("Test Item")
+      expect(e.url).toBe("https://example.com/posts/1")
+      expect(e.publishedAt).toEqual(new Date("Mon, 15 Jan 2024 10:00:00 GMT"))
+      expect(e.author).toBe("Alice")
+      expect(e.contentType).toBe("html")
+    })
+
+    it("author が email (Name) 形式なら Name だけ返す", () => {
+      const feed = parseRss2(buildFeed(buildItem()), FEED_URL)
+      expect(feed.entries[0].author).toBe("Alice")
+    })
+
+    it("dc:creator を author として使う", () => {
+      const item = buildItem("<dc:creator>Bob</dc:creator>").replace(
+        "<author>alice@example.com (Alice)</author>",
+        "",
+      )
+      const feed = parseRss2(buildFeed(item), FEED_URL)
+      expect(feed.entries[0].author).toBe("Bob")
+    })
+
+    it("link がなければ例外を投げる", () => {
+      const item = buildItem().replace(
+        "<link>https://example.com/posts/1</link>",
+        "",
+      )
+      expect(() => parseRss2(buildFeed(item), FEED_URL)).toThrow()
+    })
+
+    it("date がなければ例外を投げる", () => {
+      const item = buildItem()
+        .replace("<pubDate>Mon, 15 Jan 2024 10:00:00 GMT</pubDate>", "")
+      expect(() => parseRss2(buildFeed(item), FEED_URL)).toThrow()
+    })
+  })
+
+  describe("content", () => {
+    it("content:encoded があれば description より優先する", () => {
+      const item = buildItem(`<content:encoded>&lt;p&gt;full content&lt;/p&gt;</content:encoded>`)
+      const feed = parseRss2(buildFeed(item), FEED_URL)
+      expect(feed.entries[0].content).toBe("<p>full content</p>")
+      expect(feed.entries[0].summary).toBe("<p>Test content</p>")
+    })
+
+    it("content:encoded がなければ description を content にする", () => {
+      const feed = parseRss2(buildFeed(buildItem()), FEED_URL)
+      expect(feed.entries[0].content).toBe("<p>Test content</p>")
+      expect(feed.entries[0].summary).toBeUndefined()
+    })
+  })
+
+  describe("tags（category）", () => {
+    it("category が複数あればすべて tags に入る", () => {
+      const item = buildItem(`
+        <category>TypeScript</category>
+        <category>Bun</category>
+      `)
+      const feed = parseRss2(buildFeed(item), FEED_URL)
+      expect(feed.entries[0].tags).toEqual(["TypeScript", "Bun"])
+    })
+
+    it("category がなければ空配列", () => {
+      const feed = parseRss2(buildFeed(buildItem()), FEED_URL)
+      expect(feed.entries[0].tags).toEqual([])
+    })
+  })
+})

--- a/packages/feed-parser/src/parsers/rss2.ts
+++ b/packages/feed-parser/src/parsers/rss2.ts
@@ -1,0 +1,76 @@
+import { XMLParser } from "fast-xml-parser"
+import type { Feed, Entry } from "../types.js"
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  isArray: (name) => name === "item" || name === "category",
+})
+
+function resolveDate(value: unknown): Date | undefined {
+  if (!value) return undefined
+  const d = new Date(String(value))
+  return isNaN(d.getTime()) ? undefined : d
+}
+
+function resolveText(value: unknown): string | undefined {
+  if (typeof value === "string") return value
+  if (typeof value === "object" && value !== null && "#text" in value) {
+    return String((value as { "#text": unknown })["#text"])
+  }
+  return undefined
+}
+
+// <author> in RSS 2.0 is typically "email (Name)" or just "Name"
+function resolveAuthor(value: unknown): string | undefined {
+  const raw = resolveText(value)
+  if (!raw) return undefined
+  const match = raw.match(/\((.+?)\)/)
+  return match ? match[1] : raw
+}
+
+function resolveCategories(categories: unknown): string[] {
+  if (!Array.isArray(categories)) return []
+  return categories
+    .map((c) => (typeof c === "string" ? c : resolveText(c)))
+    .filter((t): t is string => typeof t === "string")
+}
+
+export function parseRss2(xml: string, feedUrl: string): Feed {
+  const raw = parser.parse(xml)
+  const channel = raw?.rss?.channel
+  if (!channel) throw new Error("Not a valid RSS 2.0 feed")
+
+  const entries: Entry[] = (channel.item ?? []).map((item: Record<string, unknown>) => {
+    const url = resolveText(item.link)
+    if (!url) throw new Error(`Item missing link: ${JSON.stringify(item.guid)}`)
+    const publishedAt = resolveDate(item.pubDate ?? item["dc:date"])
+    if (!publishedAt) throw new Error(`Item missing date: ${url}`)
+
+    // prefer content:encoded over description
+    const encoded = resolveText(item["content:encoded"])
+    const description = resolveText(item.description)
+    const content = encoded ?? description
+
+    return {
+      id: resolveText(item.guid) ?? url,
+      title: resolveText(item.title) ?? "(no title)",
+      url,
+      publishedAt,
+      updatedAt: undefined,
+      content,
+      contentType: "html",
+      summary: encoded ? description : undefined,
+      author: resolveAuthor(item.author ?? item["dc:creator"]),
+      tags: resolveCategories(item.category),
+    }
+  })
+
+  return {
+    title: resolveText(channel.title) ?? "(no title)",
+    feedUrl,
+    siteUrl: resolveText(channel.link),
+    description: resolveText(channel.description),
+    entries,
+  }
+}


### PR DESCRIPTION
Closes #151

## Summary

- `src/parsers/rss2.ts` — RSS 2.0 パーサー（`content:encoded` 対応、`author` の `email (Name)` 形式を name のみに正規化）
- `src/parsers/jsonfeed.ts` — JSON Feed 1.0 / 1.1 パーサー（`content_html` / `content_text` で contentType を自動判定）
- `src/parsers/rdf.ts` — RSS 1.0 / RDF パーサー（`dc:date` / `dc:creator` 対応）
- `src/index.ts` — content-type → コンテンツスニッフィングの 2 段階でフォーマットを判定しパーサーへルーティング
- `src/__fixtures__/rss2.ts` / `jsonfeed.ts` / `rdf.ts` — 各フォーマットのテストフィクスチャ追加

## Test plan

- [ ] `pnpm --filter @yomu/feed-parser test:run` — 55 tests pass