### PR TITLE
fix(feed-parser): add error messages to toThrow() assertions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,9 +4,7 @@
   "categories": {
     "correctness": "error"
   },
-  "rules": {
-    "jest/require-to-throw-message": "off"
-  },
+  "rules": {},
   "env": {
     "builtin": true
   },

--- a/packages/feed-parser/src/parsers/atom.test.ts
+++ b/packages/feed-parser/src/parsers/atom.test.ts
@@ -52,14 +52,14 @@ describe("parseAtom", () => {
         `<link rel="alternate" href="https://example.com/posts/1"/>`,
         "",
       )
-      expect(() => parseAtom(buildFeed(entry), FEED_URL)).toThrow()
+      expect(() => parseAtom(buildFeed(entry), FEED_URL)).toThrow("Entry missing link:")
     })
 
     it("date が存在しなければ例外を投げる", () => {
       const entry = buildEntry()
         .replace("<published>2024-01-15T10:00:00Z</published>", "")
         .replace("<updated>2024-01-16T12:00:00Z</updated>", "")
-      expect(() => parseAtom(buildFeed(entry), FEED_URL)).toThrow()
+      expect(() => parseAtom(buildFeed(entry), FEED_URL)).toThrow("Entry missing date:")
     })
   })
 

--- a/packages/feed-parser/src/parsers/jsonfeed.test.ts
+++ b/packages/feed-parser/src/parsers/jsonfeed.test.ts
@@ -35,12 +35,12 @@ describe("parseJsonFeed", () => {
 
     it("url がなければ例外を投げる", () => {
       const item = buildItem({ url: undefined })
-      expect(() => parseJsonFeed(buildFeed([item]), FEED_URL)).toThrow()
+      expect(() => parseJsonFeed(buildFeed([item]), FEED_URL)).toThrow("Item missing url:")
     })
 
     it("date_published がなければ例外を投げる", () => {
       const item = buildItem({ date_published: undefined })
-      expect(() => parseJsonFeed(buildFeed([item]), FEED_URL)).toThrow()
+      expect(() => parseJsonFeed(buildFeed([item]), FEED_URL)).toThrow("Item missing date_published:")
     })
   })
 

--- a/packages/feed-parser/src/parsers/rdf.test.ts
+++ b/packages/feed-parser/src/parsers/rdf.test.ts
@@ -30,7 +30,7 @@ describe("parseRdf", () => {
 
     it("dc:date がなければ例外を投げる", () => {
       const item = buildItem().replace("<dc:date>2024-01-15T10:00:00Z</dc:date>", "")
-      expect(() => parseRdf(buildFeed(item), FEED_URL)).toThrow()
+      expect(() => parseRdf(buildFeed(item), FEED_URL)).toThrow("Item missing dc:date:")
     })
 
     it("tags は常に空配列", () => {

--- a/packages/feed-parser/src/parsers/rss2.test.ts
+++ b/packages/feed-parser/src/parsers/rss2.test.ts
@@ -43,12 +43,12 @@ describe("parseRss2", () => {
 
     it("link がなければ例外を投げる", () => {
       const item = buildItem().replace("<link>https://example.com/posts/1</link>", "")
-      expect(() => parseRss2(buildFeed(item), FEED_URL)).toThrow()
+      expect(() => parseRss2(buildFeed(item), FEED_URL)).toThrow("Item missing link:")
     })
 
     it("date がなければ例外を投げる", () => {
       const item = buildItem().replace("<pubDate>Mon, 15 Jan 2024 10:00:00 GMT</pubDate>", "")
-      expect(() => parseRss2(buildFeed(item), FEED_URL)).toThrow()
+      expect(() => parseRss2(buildFeed(item), FEED_URL)).toThrow("Item missing date:")
     })
   })
 


### PR DESCRIPTION
## Summary

- 7 件の `toThrow()` に実際のエラーメッセージを指定
- `.oxlintrc.json` の `jest/require-to-throw-message: off` 抑制を削除してルールを有効化

Closes #155