### PR TITLE
feat: scaffold apps/api with Hono + tRPC skeleton

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@yomu/api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --watch src/index.ts",
+    "build": "bun build src/index.ts --outdir dist --target bun",
+    "start": "bun run dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@hono/trpc-server": "^0.4.2",
+    "@trpc/server": "^11.16.0",
+    "hono": "^4.12.15",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.13",
+    "typescript": "^5.7.3"
+  }
+}

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -1,0 +1,16 @@
+import type { FetchCreateContextFnOptions } from "@trpc/server/adapters/fetch"
+
+export type AuthUser = {
+  id: number
+  username: string
+  isAdmin: boolean
+}
+
+export type Context = {
+  user: AuthUser | null
+}
+
+export function createContext(_opts: FetchCreateContextFnOptions): Context {
+  // TODO: Google OAuth / API key 認証を実装
+  return { user: null }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,0 +1,23 @@
+import { Hono } from "hono"
+import { trpcServer } from "@hono/trpc-server"
+import { appRouter } from "./router/index.js"
+import { createContext } from "./context.js"
+
+const app = new Hono()
+
+app.get("/health", (c) => c.json({ status: "ok" }))
+
+app.use(
+  "/trpc/*",
+  trpcServer({
+    router: appRouter,
+    createContext,
+  }),
+)
+
+const port = Number(process.env.PORT ?? 3000)
+
+export default {
+  port,
+  fetch: app.fetch,
+}

--- a/apps/api/src/router/apiKey.ts
+++ b/apps/api/src/router/apiKey.ts
@@ -1,0 +1,13 @@
+import { router, authedProcedure } from "../trpc.js"
+
+export const apiKeyRouter = router({
+  list: authedProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+  create: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  remove: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+})

--- a/apps/api/src/router/category.ts
+++ b/apps/api/src/router/category.ts
@@ -1,0 +1,28 @@
+import { router, authedProcedure } from "../trpc.js"
+
+export const categoryRouter = router({
+  list: authedProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+  create: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  update: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  remove: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  feeds: authedProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+  entries: authedProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+  refresh: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  markAllAsRead: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+})

--- a/apps/api/src/router/enclosure.ts
+++ b/apps/api/src/router/enclosure.ts
@@ -1,0 +1,10 @@
+import { router, authedProcedure } from "../trpc.js"
+
+export const enclosureRouter = router({
+  get: authedProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+  updateProgression: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+})

--- a/apps/api/src/router/entry.ts
+++ b/apps/api/src/router/entry.ts
@@ -1,0 +1,37 @@
+import { z } from "zod"
+import { router, authedProcedure } from "../trpc.js"
+
+export const entryListInput = z.object({
+  status: z.enum(["unread", "read"]).optional(),
+  starred: z.boolean().optional(),
+  feedId: z.number().optional(),
+  categoryId: z.number().optional(),
+  search: z.string().optional(),
+  order: z.enum(["publishedAt", "id"]).default("publishedAt"),
+  direction: z.enum(["asc", "desc"]).default("desc"),
+  limit: z.number().min(1).max(100).default(30),
+  offset: z.number().default(0),
+  before: z.date().optional(),
+  after: z.date().optional(),
+})
+
+export const entryRouter = router({
+  list: authedProcedure.input(entryListInput).query(() => {
+    throw new Error("not implemented")
+  }),
+  get: authedProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+  updateStatus: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  toggleBookmark: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  fetchContent: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  flushHistory: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+})

--- a/apps/api/src/router/feed.ts
+++ b/apps/api/src/router/feed.ts
@@ -1,0 +1,40 @@
+import { router, authedProcedure } from "../trpc.js"
+
+export const feedRouter = router({
+  list: authedProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+  counters: authedProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+  get: authedProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+  discover: authedProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+  create: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  update: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  remove: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  refresh: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  refreshAll: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  icon: authedProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+  markAllAsRead: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  entries: authedProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+})

--- a/apps/api/src/router/index.ts
+++ b/apps/api/src/router/index.ts
@@ -1,0 +1,20 @@
+import { router } from "../trpc.js"
+import { userRouter } from "./user.js"
+import { categoryRouter } from "./category.js"
+import { feedRouter } from "./feed.js"
+import { entryRouter } from "./entry.js"
+import { enclosureRouter } from "./enclosure.js"
+import { apiKeyRouter } from "./apiKey.js"
+import { opmlRouter } from "./opml.js"
+
+export const appRouter = router({
+  user: userRouter,
+  category: categoryRouter,
+  feed: feedRouter,
+  entry: entryRouter,
+  enclosure: enclosureRouter,
+  apiKey: apiKeyRouter,
+  opml: opmlRouter,
+})
+
+export type AppRouter = typeof appRouter

--- a/apps/api/src/router/opml.ts
+++ b/apps/api/src/router/opml.ts
@@ -1,0 +1,10 @@
+import { router, authedProcedure } from "../trpc.js"
+
+export const opmlRouter = router({
+  export: authedProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+  import: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+})

--- a/apps/api/src/router/user.ts
+++ b/apps/api/src/router/user.ts
@@ -1,0 +1,20 @@
+import { router, authedProcedure, adminProcedure } from "../trpc.js"
+
+export const userRouter = router({
+  me: authedProcedure.query(({ ctx }) => ctx.user),
+  list: adminProcedure.query(() => {
+    throw new Error("not implemented")
+  }),
+  create: adminProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  update: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  remove: adminProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+  markAllAsRead: authedProcedure.mutation(() => {
+    throw new Error("not implemented")
+  }),
+})

--- a/apps/api/src/trpc.ts
+++ b/apps/api/src/trpc.ts
@@ -1,0 +1,15 @@
+import { initTRPC, TRPCError } from "@trpc/server"
+import type { Context } from "./context.js"
+
+const t = initTRPC.context<Context>().create()
+
+export const router = t.router
+export const publicProcedure = t.procedure
+export const authedProcedure = t.procedure.use(({ ctx, next }) => {
+  if (!ctx.user) throw new TRPCError({ code: "UNAUTHORIZED" })
+  return next({ ctx: { ...ctx, user: ctx.user } })
+})
+export const adminProcedure = authedProcedure.use(({ ctx, next }) => {
+  if (!ctx.user.isAdmin) throw new TRPCError({ code: "FORBIDDEN" })
+  return next({ ctx })
+})

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["bun"],
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,29 @@
   "workspaces": {
     "": {
       "name": "yomu",
+      "dependencies": {
+        "@trpc/server": "^11.16.0",
+        "hono": "^4.12.15",
+        "zod": "^4.3.6",
+      },
       "devDependencies": {
         "oxfmt": "^0.47.0",
         "oxlint": "^1.62.0",
         "turbo": "^2.7.2",
+      },
+    },
+    "apps/api": {
+      "name": "@yomu/api",
+      "version": "0.1.0",
+      "dependencies": {
+        "@hono/trpc-server": "^0.4.2",
+        "@trpc/server": "^11.16.0",
+        "hono": "^4.12.15",
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.13",
+        "typescript": "^5.7.3",
       },
     },
     "packages/feed-parser": {
@@ -24,6 +43,8 @@
     },
   },
   "packages": {
+    "@hono/trpc-server": ["@hono/trpc-server@0.4.2", "", { "peerDependencies": { "@trpc/server": "^10.10.0 || >11.0.0-rc", "hono": ">=4.0.0" } }, "sha512-3TDrc42CZLgcTFkXQba+y7JlRWRiyw1AqhLqztWyNS2IFT+3bHld0lxKdGBttCtGKHYx0505dM67RMazjhdZqw=="],
+
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.47.0", "", { "os": "android", "cpu": "arm" }, "sha512-KrMQRdMi/upr81qT4ijK6X6BNp6jqpMY7FwILQnwIy9QLc3qpnhUx5rsCLGzn4ewsCQ0CNAspN2ogmP1GXLyLw=="],
 
     "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.47.0", "", { "os": "android", "cpu": "arm64" }, "sha512-r4ixS/PeUpAFKgrpDoZ5pSkthjZzVzKd95525Aazj+aOv9H4ulK5zYHGb7wFY5n5kZxHK8TbOJUZgoEb1ohddQ=="],
@@ -100,15 +121,21 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.62.0", "", { "os": "win32", "cpu": "x64" }, "sha512-6hMpyDWQ2zGA1OXFKBrdYMUveUCO8UJhkO6JdwZPd78xIdHZNhjx+pib+4fC2Cljuhjyl0QwA2F3df/bs4Bp6A=="],
 
+    "@trpc/server": ["@trpc/server@11.16.0", "", { "peerDependencies": { "typescript": ">=5.7.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-XgGuUMddrUTd04+za/WE5GFuZ1/YU9XQG0t3VL5WOIu2JspkOlq6k4RYEiqS6HSJt+S0RXaPdIoE2anIP/BBRQ=="],
+
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@yomu/api": ["@yomu/api@workspace:apps/api"],
 
     "@yomu/feed-parser": ["@yomu/feed-parser@workspace:packages/feed-parser"],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "fast-xml-parser": ["fast-xml-parser@4.5.6", "", { "dependencies": { "strnum": "1.1.2" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A=="],
+
+    "hono": ["hono@4.12.15", "", {}, "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="],
 
     "oxfmt": ["oxfmt@0.47.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.47.0", "@oxfmt/binding-android-arm64": "0.47.0", "@oxfmt/binding-darwin-arm64": "0.47.0", "@oxfmt/binding-darwin-x64": "0.47.0", "@oxfmt/binding-freebsd-x64": "0.47.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.47.0", "@oxfmt/binding-linux-arm-musleabihf": "0.47.0", "@oxfmt/binding-linux-arm64-gnu": "0.47.0", "@oxfmt/binding-linux-arm64-musl": "0.47.0", "@oxfmt/binding-linux-ppc64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-musl": "0.47.0", "@oxfmt/binding-linux-s390x-gnu": "0.47.0", "@oxfmt/binding-linux-x64-gnu": "0.47.0", "@oxfmt/binding-linux-x64-musl": "0.47.0", "@oxfmt/binding-openharmony-arm64": "0.47.0", "@oxfmt/binding-win32-arm64-msvc": "0.47.0", "@oxfmt/binding-win32-ia32-msvc": "0.47.0", "@oxfmt/binding-win32-x64-msvc": "0.47.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA=="],
 
@@ -136,6 +163,8 @@
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@yomu/feed-parser/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,4 @@
 services:
-  postgres:
-    image: postgres:16-alpine
-    container_name: yomu-postgres
-    environment:
-      POSTGRES_USER: yomu
-      POSTGRES_PASSWORD: yomu
-      POSTGRES_DB: yomu
-    ports:
-      - "${POSTGRES_PORT:-5433}:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-      - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U yomu -d yomu"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-
-  valkey:
-    image: valkey/valkey:8-alpine
-    container_name: yomu-valkey
-    ports:
-      - "${VALKEY_PORT:-6380}:6379"
-    volumes:
-      - valkey_data:/data
-    healthcheck:
-      test: ["CMD", "valkey-cli", "ping"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-
   api:
     build:
       context: .
@@ -41,17 +10,13 @@ services:
       NODE_ENV: production
       PORT: 3000
       LOG_LEVEL: ${LOG_LEVEL:-info}
-      DATABASE_URL: postgresql://yomu:yomu@postgres:5432/yomu
-      VALKEY_URL: redis://valkey:6379
+      DATABASE_URL: /data/yomu.db
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
-      GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI:-http://localhost:8085/callback}
+      GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI:-http://localhost:3000/auth/callback}
       SESSION_SECRET: ${SESSION_SECRET}
-    depends_on:
-      postgres:
-        condition: service_healthy
-      valkey:
-        condition: service_healthy
+    volumes:
+      - db_data:/data
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/health"]
       interval: 30s
@@ -60,5 +25,4 @@ services:
       retries: 3
 
 volumes:
-  postgres_data:
-  valkey_data:
+  db_data:

--- a/package.json
+++ b/package.json
@@ -30,5 +30,10 @@
     "turbo": "^2.7.2"
   },
   "workspaces": ["apps/*", "packages/*"],
-  "packageManager": "bun@1.3.11"
+  "packageManager": "bun@1.3.11",
+  "dependencies": {
+    "@trpc/server": "^11.16.0",
+    "hono": "^4.12.15",
+    "zod": "^4.3.6"
+  }
 }


### PR DESCRIPTION
## Summary

- `docker-compose.yml` から postgres / valkey を削除し、DuckDB の volume マウント構成へ整理
- `apps/api` を新規作成
  - Hono サーバー + `/health` エンドポイント（動作確認済み）
  - `/trpc/*` に tRPC をマウント
  - specs.md の全ルーター（user/category/feed/entry/enclosure/apiKey/opml）をスタブ実装
  - tRPC コンテキスト・authedProcedure・adminProcedure を定義（認証は後続 Issue）

## Test plan

- [ ] `bun run --filter @yomu/api build` が成功すること
- [ ] `bun run --filter @yomu/api typecheck` が成功すること
- [ ] CI が green になること

Closes #159